### PR TITLE
Adds code for card 49

### DIFF
--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -18,8 +18,11 @@
         <% end %>
 
         <% unless @user.orders.empty? %>
-        <%= render "orders/orders_table" %>
-        <% end %><br>
+          <div id="profile-orders">
+            <%= render "orders/orders_table" %>
+          </div>
+        <% end %>
+        <br />
 
         <% if current_user && current_user.id == @user.id %>
           <% unless @user.merchant?  %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,7 +7,7 @@
         <p><%= @user.city %> <%= @user.state%></p>
         <p><%= @user.zipcode %></p>
         <p><%= @user.email %></p>
-        <h5>You've been a member with us since <%= @user.created_at.strftime("%A %B %d, %Y") %></h5>
+        <h5>Member since: <%= @user.created_at.strftime("%A %B %d, %Y") %></h5>
         <p>Authorization level: <%= @user.role %></p>
 
 
@@ -22,11 +22,11 @@
         <% end %><br>
 
         <% if current_user && current_user.id == @user.id %>
-        <% unless @user.merchant?  %>
-        <div id="edit_link">
-          <%= link_to "Edit Information", profile_edit_path, method: :GET %>
-        </div><br>
-        <% end %>
+          <% unless @user.merchant?  %>
+            <div id="edit_link">
+              <%= link_to "Edit Information", profile_edit_path, method: :GET %>
+            </div><br>
+          <% end %>
         <% end %>
       </div>
     </div>

--- a/spec/features/admin_can_see_user_profile_spec.rb
+++ b/spec/features/admin_can_see_user_profile_spec.rb
@@ -22,9 +22,12 @@ require 'rails_helper'
         expect(page).to have_content(user_1.email)
         expect(page).not_to have_content(user_1.password)
         expect(page).to have_content(user_1.role)
-        expect(page).to have_css(".orders-table")
-        
         expect(page).to_not have_link("View My Items", href: dashboard_items_path)
+
+        within("#profile-orders") do
+          expect(page).to have_css(".orders-table")
+          expect(page).to have_content(order_1.id)
+        end
       end
     end
   end

--- a/spec/features/admin_can_see_user_profile_spec.rb
+++ b/spec/features/admin_can_see_user_profile_spec.rb
@@ -1,14 +1,16 @@
-
 require 'rails_helper'
-
 
   describe 'As an admin' do
     context 'visiting a user profile page' do
       it 'sees all the information a user would see' do
 
         admin_1 = create(:admin)
-        user_1 = create(:user, role: 0)
-          allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
+        merchant_1 = create(:merchant)
+        user_1 = create(:user)
+        order_1 = create(:order, user: user_1)
+        item_1 = create(:item, user: merchant_1)
+        OrderItem.create(item: item_1, order: order_1, quantity: 5, price: 100)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin_1)
 
         visit admin_user_path(user_1)
 
@@ -20,7 +22,8 @@ require 'rails_helper'
         expect(page).to have_content(user_1.email)
         expect(page).not_to have_content(user_1.password)
         expect(page).to have_content(user_1.role)
-
+        expect(page).to have_css(".orders-table")
+        
         expect(page).to_not have_link("View My Items", href: dashboard_items_path)
       end
     end

--- a/spec/features/merchant_can_see_their_own_dashboard_spec.rb
+++ b/spec/features/merchant_can_see_their_own_dashboard_spec.rb
@@ -35,7 +35,7 @@ describe 'A merchant who logs into our web app' do
       expect(page).to have_content(merchant_1.state)
       expect(page).to have_content(merchant_1.zipcode)
       expect(page).to have_content(merchant_1.email)
-      expect(page).to have_content("You've been a member with us since #{merchant_1.created_at.strftime("%A %B %d, %Y")}")
+      expect(page).to have_content("Member since: #{merchant_1.created_at.strftime("%A %B %d, %Y")}")
       expect(page).to have_content("Authorization level: #{merchant_1.role}")
       expect(page).to have_no_content("Edit Information")
   end

--- a/spec/features/user_can_see_profile_spec.rb
+++ b/spec/features/user_can_see_profile_spec.rb
@@ -15,17 +15,6 @@ describe 'on a users profile page' do
       expect(page).to have_content(@user.zipcode)
       expect(page).to have_content(@user.email)
       expect(page).not_to have_content(@user.password)
-
-    end
-
-    it 'can see a link to edit profile' do
-      expect(page).to have_content(@user.name)
-      expect(page).to have_content(@user.address)
-      expect(page).to have_content(@user.city)
-      expect(page).to have_content(@user.state)
-      expect(page).to have_content(@user.zipcode)
-      expect(page).to have_content(@user.email)
-
       expect(page).to have_content("Edit Information")
     end
   end


### PR DESCRIPTION
- [x] Wrote Tests
- [x] Implemented
- [] Reviewed

# Necessary checkmarks:
- [x] All Tests are Passing
- [x] The code will run locally

## Type of change
- [x] New feature
- [] Bug Fix

# Implements/Fixes:
* description

THE main purpose of this branch is to add the order information to the admin_user_path(userid). This way, when an administrator views a user profile they can see the exact same info that a user would see on their own profile, including their order information where applicable.
-made the "member since" be less personalized so that it works with both the admin user profile view and the regular registered user profile view.
-fixed some messy indentation and trailing whitespace
-added tests to admin_can_see_user_profile_spec.rb
-furthermore, i made a change to DRY up the user_can_see_profile_spec.rb file because there were messy and redundant assertions.
* closes #49 
As an admin user
When I visit a user's profile page
I see the same order data that the user sees


# Check the correct boxes
- [x] This broke nothing
- [] This broke some stuff
- [] This broke everything

# Testing Changes
- [] No Tests have been changed
- [x] Some Tests have been changed

# Please include a link to a gif of how you feel about this branch:
http://gph.is/2mwhJCC